### PR TITLE
refactor(ci/nextjs): comment out unused static_site_generator config in workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -66,12 +66,12 @@ jobs:
         run: pnpm install --no-frozen-lockfile
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
+        # with:
+        #   # Automatically inject basePath in your Next.js configuration file and disable
+        #   # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+        #   #
+        #   # You may remove this line if you want to manage the configuration yourself.
+        #   static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
- Comment out the static_site_generator input for actions/configure-pages@v5 to manage configuration manually
