### PR TITLE
Add help option to new-post script and create new-post skill

### DIFF
--- a/.github/skills/create-new-post/SKILL.md
+++ b/.github/skills/create-new-post/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: create-new-post
+description: "Automate creating a new blog post using pnpm new-post when asked to 'create a post' or similar."
+---
+
+## Purpose
+
+Automate and standardize the process of creating a new blog post in this workspace using the `pnpm new-post` command.
+
+## Workflow
+
+1. When the user asks to "create a post" or similar:
+   - Run `pnpm new-post` in the project root.
+   - Follow the interactive prompts to enter:
+     - slug (used in filename)
+     - title (defaults to slug if empty)
+     - tags (space-separated, optional)
+2. If the user requests help or usage info, run `pnpm new-post --help` to display instructions.
+3. If a file with the same slug and date exists, confirm with the user before overwriting.
+
+## Decision Points
+
+- If the user provides all required info (slug, title, tags) in the prompt, pass them interactively or pre-fill if possible.
+- If the file exists, ask the user to confirm overwriting.
+
+## Quality Criteria
+
+- The new post file is created in `src/pages/posts/` with the correct date and slug.
+- The frontmatter includes the provided title and tags.
+- The user is notified of the file path and any overwrite actions.
+
+## Example Prompts
+
+- "Create a new post titled 'My Journey' with tags travel adventure."
+- "Add a blog post called '2026 Review'."
+- "pnpm new-post --help"
+
+## Related Customizations
+
+- Automate filling prompts from a single command.
+- Add validation for slug format.
+- Extend to support drafts or scheduled posts.

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -2,6 +2,15 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 
+function printHelpAndExit() {
+  console.log(`Usage: node scripts/new-post.js\n\nOptions:\n  -h, --help    Show this help message and exit\n\nThis script will interactively prompt for:\n  slug         The post slug (used in filename)\n  title        The post title (defaults to slug if empty)\n  tags         Space-separated tags (optional)\n\nExample:\n  node scripts/new-post.js\n`);
+  process.exit(0);
+}
+
+if (process.argv.includes('-h') || process.argv.includes('--help')) {
+  printHelpAndExit();
+}
+
 const ri = readline.createInterface({
   input: process.stdin,
   output: process.stdout,

--- a/src/pages/posts/2026-04-29-agent-skill-create-post.mdx
+++ b/src/pages/posts/2026-04-29-agent-skill-create-post.mdx
@@ -1,0 +1,40 @@
+---
+title: Agent Skill create post
+tags:
+  - skill
+---
+
+## Using Agent Skill to Create a New Post
+
+This article demonstrates how to use an agent skill to automate the creation of a new blog post in this project.
+
+### Why automate post creation?
+
+- Ensures consistency in file naming and frontmatter
+- Reduces manual errors
+- Saves time for frequent bloggers
+
+### How it works
+
+1. The agent skill listens for prompts like "create a new post".
+2. It runs the `pnpm new-post` command, which triggers an interactive script.
+3. The script collects the slug, title, and tags, then generates a new MDX file in `src/pages/posts/`.
+
+### Example
+
+Suppose you want to create a post about using agent skills:
+
+- **Slug:** agent-skill-create-post
+- **Title:** Agent Skill create post
+- **Tags:** skill
+
+The agent skill will:
+
+- Run the command
+- Fill in the prompts
+- Create `src/pages/posts/2026-04-29-agent-skill-create-post.mdx` with the correct frontmatter
+
+### Benefits
+
+- Streamlined workflow for content creators
+- Easy to extend for more metadata or templates


### PR DESCRIPTION
This pull request introduces automation and documentation for creating new blog posts using an agent skill and the `pnpm new-post` workflow. It adds a new agent skill specification, improves the user experience for the interactive script, and provides user-facing documentation and examples.

**Agent skill automation and documentation:**

* Added `.github/skills/create-new-post/SKILL.md` to define an agent skill that automates blog post creation via `pnpm new-post`, including workflow, decision points, and quality criteria.
* Added a new post, `src/pages/posts/2026-04-29-agent-skill-create-post.mdx`, documenting how to use the agent skill to automate post creation, including rationale, workflow, and benefits.

**Script usability improvements:**

* Updated `scripts/new-post.js` to support `-h`/`--help` flags, displaying usage instructions and exiting early for user guidance.